### PR TITLE
Enhance site with responsive nav, richer components, and SEO improvements

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -1,21 +1,114 @@
 import Link from 'next/link';
 import Image, { StaticImageData } from 'next/image';
+import { useState, useRef, useCallback } from 'react';
+
+type CardVariant = 'default' | 'featured' | 'compact';
+
+interface TagProps {
+  label: string;
+  color?: 'blue' | 'green' | 'purple' | 'orange' | 'slate';
+}
 
 interface ICard {
   title: string;
   desc: string;
   to: string;
   image: StaticImageData;
+  variant?: CardVariant;
+  tags?: TagProps[];
+  date?: string;
+  isExternal?: boolean;
 }
 
-function Card({ title, desc, to, image }: ICard): JSX.Element {
+const tagColorMap: Record<NonNullable<TagProps['color']>, string> = {
+  blue: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+  green: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
+  purple: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300',
+  orange: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300',
+  slate: 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300',
+};
+
+const variantStyles: Record<CardVariant, string> = {
+  default: 'py-3 md:px-6 md:py-5 rounded-xl flex gap-4 items-center',
+  featured: 'p-6 rounded-2xl flex flex-col sm:flex-row gap-6 items-start border border-slate-200 dark:border-slate-700 shadow-sm',
+  compact: 'py-2 px-3 rounded-lg flex gap-3 items-center',
+};
+
+function Tag({ label, color = 'slate' }: TagProps) {
   return (
-    <Link href={to}>
-      <div className='py-3 md:px-6 md:py-5 md:hover:bg-[#64646426] rounded-xl flex gap-4 items-center'>
-        <Image src={image} alt='A picture of me!' width={60} height={60} />
-        <div>
-          <h2 className='leading-6'>{title}</h2>
-          <p className='leading-8 text-neutral-400'>{desc}</p>
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${tagColorMap[color]}`}>
+      {label}
+    </span>
+  );
+}
+
+function Card({ title, desc, to, image, variant = 'default', tags, date, isExternal }: ICard): JSX.Element {
+  const [isHovered, setIsHovered] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseEnter = useCallback(() => setIsHovered(true), []);
+  const handleMouseLeave = useCallback(() => setIsHovered(false), []);
+
+  const imageSize = variant === 'featured' ? 80 : variant === 'compact' ? 40 : 60;
+
+  return (
+    <Link
+      href={to}
+      target={isExternal ? '_blank' : undefined}
+      rel={isExternal ? 'noopener noreferrer' : undefined}
+    >
+      <div
+        ref={cardRef}
+        className={`${variantStyles[variant]} transition-all duration-200 ${
+          isHovered
+            ? 'bg-slate-50 dark:bg-slate-800/50 shadow-md -translate-y-0.5'
+            : 'md:hover:bg-[#64646426]'
+        }`}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <div className="relative flex-shrink-0">
+          <Image
+            src={image}
+            alt={`${title} thumbnail`}
+            width={imageSize}
+            height={imageSize}
+            className={`rounded-lg object-cover transition-transform duration-200 ${
+              isHovered ? 'scale-105' : ''
+            }`}
+          />
+          {isExternal && (
+            <div className="absolute -top-1 -right-1 bg-white dark:bg-slate-800 rounded-full p-0.5 shadow-sm">
+              <svg className="w-3 h-3 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+              </svg>
+            </div>
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <h2 className={`leading-6 truncate ${variant === 'featured' ? 'text-lg font-semibold' : ''}`}>
+              {title}
+            </h2>
+            {isExternal && (
+              <svg className="w-4 h-4 text-slate-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+              </svg>
+            )}
+          </div>
+          <p className={`leading-relaxed text-neutral-400 ${variant === 'compact' ? 'text-sm' : ''}`}>
+            {desc}
+          </p>
+          {(tags || date) && (
+            <div className="flex items-center gap-2 mt-2 flex-wrap">
+              {date && (
+                <span className="text-xs text-slate-400 dark:text-slate-500">{date}</span>
+              )}
+              {tags?.map((tag) => (
+                <Tag key={tag.label} {...tag} />
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </Link>

--- a/components/description-row.tsx
+++ b/components/description-row.tsx
@@ -1,30 +1,114 @@
-import React from "react";
+import React, { ReactNode } from "react";
+import Link from "next/link";
+
+type DescriptionRowSize = "default" | "large" | "small";
 
 interface DescriptionRowProps {
   title: string;
   descriptionPrimary: string;
   descriptionSecondary?: string;
+  href?: string;
+  icon?: ReactNode;
+  size?: DescriptionRowSize;
+  badge?: string;
+  metadata?: string;
 }
+
+const sizeStyles: Record<DescriptionRowSize, { title: string; description: string }> = {
+  large: {
+    title: "text-lg font-semibold mb-1.5",
+    description: "text-base",
+  },
+  default: {
+    title: "text-base font-medium mb-1",
+    description: "text-sm",
+  },
+  small: {
+    title: "text-sm font-medium mb-0.5",
+    description: "text-xs",
+  },
+};
 
 export const DescriptionRow: React.FC<DescriptionRowProps> = ({
   title,
   descriptionPrimary,
   descriptionSecondary,
+  href,
+  icon,
+  size = "default",
+  badge,
+  metadata,
 }) => {
-  return (
-    <div>
-      <h3 className="mb-1">{title}</h3>
-      <p className="flex flex-row gap-2 mb-0 text-slate-600 dark:text-slate-400">
-        {descriptionPrimary}
-        {descriptionSecondary && (
-          <>
-            <span className="text-2xl font-bold leading-4 text-blue-400">
-              .
+  const styles = sizeStyles[size];
+
+  const content = (
+    <div className={`flex items-start gap-3 group ${href ? "cursor-pointer" : ""}`}>
+      {/* Optional icon */}
+      {icon && (
+        <div className="flex-shrink-0 mt-0.5 w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 flex items-center justify-center text-slate-500 dark:text-slate-400 group-hover:bg-blue-50 dark:group-hover:bg-blue-900/20 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+          {icon}
+        </div>
+      )}
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <h3
+            className={`${styles.title} ${
+              href
+                ? "group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors"
+                : ""
+            }`}
+          >
+            {title}
+          </h3>
+          {badge && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+              {badge}
             </span>
-            {descriptionSecondary}
-          </>
+          )}
+        </div>
+
+        <p className={`flex flex-row items-center gap-2 mb-0 text-slate-600 dark:text-slate-400 ${styles.description}`}>
+          {descriptionPrimary}
+          {descriptionSecondary && (
+            <>
+              <span className="text-2xl font-bold leading-4 text-blue-400">
+                .
+              </span>
+              <span>{descriptionSecondary}</span>
+            </>
+          )}
+        </p>
+
+        {metadata && (
+          <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">{metadata}</p>
         )}
-      </p>
+      </div>
+
+      {/* Arrow indicator for linked rows */}
+      {href && (
+        <div className="flex-shrink-0 mt-1 text-slate-300 dark:text-slate-600 group-hover:text-blue-500 dark:group-hover:text-blue-400 transition-colors">
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </div>
+      )}
     </div>
   );
+
+  if (href) {
+    const isExternal = href.startsWith("http");
+    return (
+      <Link
+        href={href}
+        target={isExternal ? "_blank" : undefined}
+        rel={isExternal ? "noopener noreferrer" : undefined}
+        className="block rounded-lg -mx-3 px-3 py-2 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors"
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return <div>{content}</div>;
 };

--- a/components/experience.tsx
+++ b/components/experience.tsx
@@ -1,10 +1,14 @@
-import React from "react";
+import React, { useState, useMemo } from "react";
 import { DescriptionRow } from "./description-row";
 
 interface ExperienceData {
   title: string;
   company: string;
   description: string;
+  skills: string[];
+  highlights?: string[];
+  companyUrl?: string;
+  isCurrent?: boolean;
 }
 
 const experiences: ExperienceData[] = [
@@ -12,51 +16,202 @@ const experiences: ExperienceData[] = [
     title: "Staff Product Designer, Copilot",
     company: "GitHub",
     description: "2025 - Present",
+    skills: ["AI/ML", "Design Systems", "Developer Tools", "Prototyping"],
+    highlights: [
+      "Leading design for GitHub Copilot's core chat and inline experiences",
+      "Defining interaction patterns for AI-assisted software development",
+      "Collaborating with research to validate novel AI UX paradigms",
+    ],
+    companyUrl: "https://github.com",
+    isCurrent: true,
   },
   {
     title: "Principal Designer, VS Code",
     company: "Microsoft",
     description: "2024",
+    skills: ["Design Leadership", "Developer Tools", "Accessibility", "Extensions"],
+    highlights: [
+      "Led design strategy across VS Code's editor and extension ecosystem",
+      "Drove adoption of new interaction patterns used by millions of developers",
+    ],
+    companyUrl: "https://code.visualstudio.com",
   },
   {
     title: "Senior Designer, VS Code",
     company: "Microsoft",
     description: "2021 — 2024",
+    skills: ["UI Design", "Design Systems", "User Research", "Prototyping"],
+    highlights: [
+      "Designed the Merge Editor, Command Center, and Profiles features",
+      "Modernized VS Code's default themes for accessibility compliance",
+      "Shipped the Webview UI Toolkit component library",
+    ],
+    companyUrl: "https://code.visualstudio.com",
   },
   {
     title: "Senior Designer, Product Insights",
     company: "Microsoft",
     description: "2019 — 2021",
+    skills: ["Data Visualization", "Dashboard Design", "Enterprise UX"],
+    highlights: [
+      "Designed analytics dashboards used across Microsoft product teams",
+      "Led design for telemetry exploration and insight discovery tools",
+    ],
   },
   {
     title: "Designer 2, Aria",
     company: "Microsoft",
     description: "2018 — 2019",
+    skills: ["Telemetry", "SDK Design", "Documentation"],
   },
   {
     title: "Designer, Aria",
     company: "Microsoft",
     description: "2016 — 2018",
+    skills: ["UX Design", "Interaction Design", "Onboarding"],
   },
   {
     title: "Intern, HoloLens",
     company: "8ninths",
     description: "2015",
+    skills: ["Mixed Reality", "3D UI", "Spatial Design"],
+    highlights: [
+      "Prototyped mixed reality interfaces for enterprise HoloLens applications",
+    ],
   },
 ];
 
+type FilterOption = "all" | "GitHub" | "Microsoft" | "8ninths";
+
+const filterOptions: FilterOption[] = ["all", "GitHub", "Microsoft", "8ninths"];
+
 export const ExperienceList: React.FC = () => {
+  const [filter, setFilter] = useState<FilterOption>("all");
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
+  const filteredExperiences = useMemo(() => {
+    if (filter === "all") return experiences;
+    return experiences.filter((exp) => exp.company === filter);
+  }, [filter]);
+
+  const totalYears = useMemo(() => {
+    const startYear = 2015;
+    const currentYear = new Date().getFullYear();
+    return currentYear - startYear;
+  }, []);
+
+  const toggleExpanded = (index: number) => {
+    setExpandedIndex(expandedIndex === index ? null : index);
+  };
+
   return (
-    <div className="flex-col">
-      <h2 className="mt-0 font-base font-semibold text-blue-600 dark:text-blue-400">Experience</h2>
-      <div className="flex flex-col gap-6">
-        {experiences.map((experience, index) => (
-          <DescriptionRow
-            key={index}
-            title={experience.title}
-            descriptionPrimary={experience.company}
-            descriptionSecondary={experience.description}
-          />
+    <div id="experience" className="flex-col scroll-mt-24">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-2">
+        <div>
+          <h2 className="mt-0 font-base font-semibold text-blue-600 dark:text-blue-400">
+            Experience
+          </h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            {totalYears}+ years in product design and developer tools
+          </p>
+        </div>
+
+        {/* Filter pills */}
+        <div className="flex gap-2 flex-wrap">
+          {filterOptions.map((option) => (
+            <button
+              key={option}
+              onClick={() => setFilter(option)}
+              className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                filter === option
+                  ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+                  : "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700"
+              }`}
+            >
+              {option === "all" ? "All" : option}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        {filteredExperiences.map((experience, index) => (
+          <div
+            key={`${experience.company}-${experience.title}`}
+            className={`relative pl-6 border-l-2 transition-colors ${
+              experience.isCurrent
+                ? "border-blue-400 dark:border-blue-500"
+                : "border-slate-200 dark:border-slate-700"
+            }`}
+          >
+            {/* Timeline dot */}
+            <div
+              className={`absolute -left-[7px] top-2 w-3 h-3 rounded-full border-2 ${
+                experience.isCurrent
+                  ? "bg-blue-400 border-blue-400 dark:bg-blue-500 dark:border-blue-500"
+                  : "bg-white dark:bg-slate-900 border-slate-300 dark:border-slate-600"
+              }`}
+            />
+
+            <div
+              className="py-4 cursor-pointer group"
+              onClick={() => toggleExpanded(index)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => e.key === "Enter" && toggleExpanded(index)}
+            >
+              <DescriptionRow
+                title={experience.title}
+                descriptionPrimary={experience.company}
+                descriptionSecondary={experience.description}
+              />
+
+              {/* Skills */}
+              <div className="flex gap-1.5 mt-3 flex-wrap">
+                {experience.skills.map((skill) => (
+                  <span
+                    key={skill}
+                    className="px-2 py-0.5 rounded-md text-xs bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400"
+                  >
+                    {skill}
+                  </span>
+                ))}
+              </div>
+
+              {/* Expandable highlights */}
+              {experience.highlights && expandedIndex === index && (
+                <ul className="mt-4 space-y-2">
+                  {experience.highlights.map((highlight, hIdx) => (
+                    <li
+                      key={hIdx}
+                      className="flex items-start gap-2 text-sm text-slate-600 dark:text-slate-400"
+                    >
+                      <span className="mt-1.5 w-1 h-1 rounded-full bg-slate-400 flex-shrink-0" />
+                      {highlight}
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {/* Expand hint */}
+              {experience.highlights && (
+                <button
+                  className="mt-2 text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors flex items-center gap-1"
+                  aria-label={expandedIndex === index ? "Collapse details" : "Expand details"}
+                >
+                  <svg
+                    className={`w-3 h-3 transition-transform ${expandedIndex === index ? "rotate-180" : ""}`}
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                  </svg>
+                  {expandedIndex === index ? "Less" : "More"}
+                </button>
+              )}
+            </div>
+          </div>
         ))}
       </div>
     </div>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,17 +1,127 @@
 import Link from "next/link";
 
+interface SocialLink {
+  label: string;
+  href: string;
+  icon: React.ReactNode;
+}
+
+const socialLinks: SocialLink[] = [
+  {
+    label: "Twitter",
+    href: "https://twitter.com/david_dossett",
+    icon: (
+      <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+      </svg>
+    ),
+  },
+  {
+    label: "GitHub",
+    href: "https://github.com/daviddossett",
+    icon: (
+      <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+        <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+      </svg>
+    ),
+  },
+  {
+    label: "LinkedIn",
+    href: "https://www.linkedin.com/in/davidcdossett/",
+    icon: (
+      <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+        <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+      </svg>
+    ),
+  },
+];
+
+const footerNavSections = [
+  {
+    title: "Pages",
+    links: [
+      { label: "Home", href: "/" },
+      { label: "Work", href: "/#projects" },
+      { label: "Experience", href: "/#experience" },
+      { label: "Writing", href: "/writing" },
+    ],
+  },
+  {
+    title: "Projects",
+    links: [
+      { label: "GitHub Copilot", href: "/github-copilot" },
+      { label: "VS Code", href: "https://code.visualstudio.com", isExternal: true },
+      { label: "Grid Playground", href: "https://grid.layoutit.com", isExternal: true },
+    ],
+  },
+];
+
 export const Footer: React.FC = () => {
+  const currentYear = new Date().getFullYear();
+
   return (
-    <div className="flex space-x-4 gap-1 py-16">
-      <Link href="https://twitter.com/david_dossett" target="blank">
-        Twitter
-      </Link>
-      <Link href="https://github.com/daviddossett" target="blank">
-        GitHub
-      </Link>
-      <Link href="https://www.linkedin.com/in/davidcdossett/" target="blank">
-        LinkedIn
-      </Link>
-    </div>
+    <footer className="border-t border-slate-200 dark:border-slate-700 mt-24">
+      <div className="py-12 flex flex-col md:flex-row gap-12 md:gap-24">
+        {/* Brand section */}
+        <div className="flex flex-col gap-4 md:max-w-xs">
+          <p className="text-base font-medium text-slate-900 dark:text-slate-200">
+            David Dossett
+          </p>
+          <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed">
+            Product designer building tools that help developers write better software.
+            Currently at GitHub working on Copilot.
+          </p>
+          <div className="flex gap-4 mt-2">
+            {socialLinks.map((link) => (
+              <Link
+                key={link.label}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+                aria-label={link.label}
+              >
+                {link.icon}
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        {/* Navigation sections */}
+        <div className="flex gap-16 md:gap-24">
+          {footerNavSections.map((section) => (
+            <div key={section.title} className="flex flex-col gap-3">
+              <p className="text-sm font-semibold text-slate-900 dark:text-slate-200">
+                {section.title}
+              </p>
+              <ul className="flex flex-col gap-2">
+                {section.links.map((link) => (
+                  <li key={link.label}>
+                    <Link
+                      href={link.href}
+                      target={"isExternal" in link && link.isExternal ? "_blank" : undefined}
+                      rel={"isExternal" in link && link.isExternal ? "noopener noreferrer" : undefined}
+                      className="text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300 transition-colors"
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Copyright bar */}
+      <div className="border-t border-slate-200 dark:border-slate-700 py-6 flex flex-col sm:flex-row justify-between items-center gap-4">
+        <p className="text-xs text-slate-400 dark:text-slate-500">
+          © {currentYear} David Dossett. All rights reserved.
+        </p>
+        <p className="text-xs text-slate-400 dark:text-slate-500">
+          Built with Next.js and Tailwind CSS
+        </p>
+      </div>
+    </footer>
   );
 };

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,15 +1,130 @@
 import Link from "next/link";
+import { useState, useCallback, useEffect } from "react";
+
+interface NavItem {
+  label: string;
+  href: string;
+  isExternal?: boolean;
+}
+
+const navItems: NavItem[] = [
+  { label: "Work", href: "/#projects" },
+  { label: "Experience", href: "/#experience" },
+  { label: "Writing", href: "/writing" },
+  { label: "GitHub", href: "https://github.com/daviddossett", isExternal: true },
+];
 
 export const Header: React.FC = () => {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [hasScrolled, setHasScrolled] = useState(false);
+
+  const toggleMobileMenu = useCallback(() => {
+    setIsMobileMenuOpen((prev) => !prev);
+  }, []);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setHasScrolled(window.scrollY > 16);
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    if (isMobileMenuOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isMobileMenuOpen]);
+
   return (
-    <header className="flex justify-between items-center pt-8">
+    <header
+      className={`sticky top-0 z-50 flex justify-between items-center pt-8 pb-4 transition-all duration-200 ${
+        hasScrolled
+          ? "bg-white/80 dark:bg-slate-900/80 backdrop-blur-md border-b border-slate-200 dark:border-slate-700"
+          : "bg-transparent"
+      }`}
+    >
       <h1 className="flex justify-items-center gap-2 text-base font-normal dark:text-slate-400">
-        <Link className="text-base font-normal text-slate-900 dark:text-slate-400" href="/">
+        <Link className="text-base font-normal text-slate-900 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-300 transition-colors" href="/">
           David Dossett
         </Link>
         <span className="text-2xl font-bold leading-3 text-blue-400">.</span>
-        Seattle, WA
+        <span className="hidden sm:inline">Seattle, WA</span>
       </h1>
+
+      {/* Desktop navigation */}
+      <nav className="hidden md:flex items-center gap-6">
+        {navItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            target={item.isExternal ? "_blank" : undefined}
+            rel={item.isExternal ? "noopener noreferrer" : undefined}
+            className="text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-200 transition-colors"
+          >
+            {item.label}
+            {item.isExternal && (
+              <svg
+                className="inline-block ml-1 w-3 h-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                />
+              </svg>
+            )}
+          </Link>
+        ))}
+      </nav>
+
+      {/* Mobile menu button */}
+      <button
+        className="md:hidden p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+        onClick={toggleMobileMenu}
+        aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+        aria-expanded={isMobileMenuOpen}
+      >
+        {isMobileMenuOpen ? (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        ) : (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        )}
+      </button>
+
+      {/* Mobile menu overlay */}
+      {isMobileMenuOpen && (
+        <div className="fixed inset-0 top-[72px] z-40 bg-white dark:bg-slate-900 md:hidden">
+          <nav className="flex flex-col p-6 gap-2">
+            {navItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                target={item.isExternal ? "_blank" : undefined}
+                rel={item.isExternal ? "noopener noreferrer" : undefined}
+                className="text-lg py-3 px-4 rounded-lg text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      )}
     </header>
   );
 };

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,41 +1,174 @@
 import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect, useState, createContext, useContext, ReactNode } from "react";
 import { Header } from "./header";
 
-interface LayoutProps {
-  children: any;
-  title?: string;
-  description?: string;
+type Theme = "light" | "dark" | "system";
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  resolvedTheme: "light" | "dark";
 }
 
-function Layout({ children, title, description }: LayoutProps): JSX.Element {
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: "system",
+  setTheme: () => {},
+  resolvedTheme: "light",
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("system");
+  const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as Theme | null;
+    if (stored && ["light", "dark", "system"].includes(stored)) {
+      setTheme(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    const resolve = () => {
+      if (theme === "system") {
+        setResolvedTheme(mediaQuery.matches ? "dark" : "light");
+      } else {
+        setResolvedTheme(theme);
+      }
+    };
+
+    resolve();
+    mediaQuery.addEventListener("change", resolve);
+    return () => mediaQuery.removeEventListener("change", resolve);
+  }, [theme]);
+
+  useEffect(() => {
+    localStorage.setItem("theme", theme);
+    const root = document.documentElement;
+    if (resolvedTheme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+  }, [theme, resolvedTheme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, resolvedTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+interface LayoutProps {
+  children: ReactNode;
+  title?: string;
+  description?: string;
+  ogImage?: string;
+  noIndex?: boolean;
+}
+
+function Layout({ children, title, description, ogImage, noIndex }: LayoutProps): JSX.Element {
+  const router = useRouter();
   const isDev = process.env.NODE_ENV === "development";
   const pageTitle = title || "David Dossett";
   const fullTitle = isDev ? `${pageTitle} — Dev` : pageTitle;
-  const pageDescription = description || "Product designer at GitHub";
+  const pageDescription = description || "Product designer at GitHub building Copilot. Previously led design for VS Code at Microsoft.";
   const siteUrl = "https://ddossett.com";
+  const canonicalUrl = `${siteUrl}${router.asPath === "/" ? "" : router.asPath}`;
+  const ogImageUrl = ogImage || `${siteUrl}/og-image.png`;
+
+  // Structured data for SEO
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "David Dossett",
+    url: siteUrl,
+    jobTitle: "Staff Product Designer",
+    worksFor: {
+      "@type": "Organization",
+      name: "GitHub",
+      url: "https://github.com",
+    },
+    sameAs: [
+      "https://twitter.com/david_dossett",
+      "https://github.com/daviddossett",
+      "https://www.linkedin.com/in/davidcdossett/",
+    ],
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: "Seattle",
+      addressRegion: "WA",
+      addressCountry: "US",
+    },
+  };
+
+  // Track page views
+  useEffect(() => {
+    const handleRouteChange = (url: string) => {
+      if (typeof window !== "undefined" && (window as any).gtag) {
+        (window as any).gtag("config", "G-XXXXXXXXXX", {
+          page_path: url,
+        });
+      }
+    };
+    router.events.on("routeChangeComplete", handleRouteChange);
+    return () => router.events.off("routeChangeComplete", handleRouteChange);
+  }, [router.events]);
 
   return (
-    <div className="max-w-[960px] mx-auto w-full px-4">
+    <div className="max-w-[960px] mx-auto w-full px-4 min-h-screen flex flex-col">
       <Head>
         <title>{fullTitle}</title>
         <meta name="description" content={pageDescription} />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta charSet="utf-8" />
+
+        {/* Canonical URL */}
+        <link rel="canonical" href={canonicalUrl} />
+
+        {/* Robots */}
+        {noIndex && <meta name="robots" content="noindex, nofollow" />}
 
         {/* Open Graph */}
         <meta property="og:title" content={fullTitle} />
         <meta property="og:description" content={pageDescription} />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content={siteUrl} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:image" content={ogImageUrl} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:site_name" content="David Dossett" />
+        <meta property="og:locale" content="en_US" />
 
         {/* Twitter */}
-        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@david_dossett" />
+        <meta name="twitter:creator" content="@david_dossett" />
         <meta name="twitter:title" content={fullTitle} />
         <meta name="twitter:description" content={pageDescription} />
+        <meta name="twitter:image" content={ogImageUrl} />
 
+        {/* Favicons */}
         <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+        <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+        <link rel="manifest" href="/site.webmanifest" />
+        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)" />
+
+        {/* Structured Data */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
       </Head>
       <Header />
-      {children}
+      <div className="flex-1">{children}</div>
     </div>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,37 +3,183 @@ import { Footer } from "../components/footer";
 import Link from "next/link";
 import { ExperienceList } from "../components/experience";
 import { Projects } from "../components/projects";
+import { useEffect, useState, useRef } from "react";
 
 const githubLink = (
-  <Link className="intro" href="https://github.com" target="blank">
+  <Link className="intro" href="https://github.com" target="_blank" rel="noopener noreferrer">
     GitHub
   </Link>
 );
 
 const copilotLink = (
-  <Link className="intro" href="https://github.com/features/copilot" target="blank">
+  <Link className="intro" href="https://github.com/features/copilot" target="_blank" rel="noopener noreferrer">
     Copilot
   </Link>
 );
 
 const vsCodeLink = (
-  <Link className="intro" href="https://code.visualstudio.com" target="blank">
+  <Link className="intro" href="https://code.visualstudio.com" target="_blank" rel="noopener noreferrer">
     VS Code
   </Link>
 );
 
+interface StatItem {
+  label: string;
+  value: string;
+  description: string;
+}
+
+const stats: StatItem[] = [
+  { label: "Years in Design", value: "10+", description: "Building developer tools since 2015" },
+  { label: "Products Shipped", value: "20+", description: "Across GitHub and Microsoft" },
+  { label: "Users Impacted", value: "Millions", description: "VS Code has 15M+ monthly active users" },
+];
+
+function useIntersectionObserver(threshold = 0.1) {
+  const [isVisible, setIsVisible] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold }
+    );
+
+    const currentRef = ref.current;
+    if (currentRef) {
+      observer.observe(currentRef);
+    }
+
+    return () => {
+      if (currentRef) {
+        observer.unobserve(currentRef);
+      }
+    };
+  }, [threshold]);
+
+  return { ref, isVisible };
+}
+
+function StatsSection() {
+  const { ref, isVisible } = useIntersectionObserver(0.2);
+
+  return (
+    <div
+      ref={ref}
+      className={`grid grid-cols-1 sm:grid-cols-3 gap-8 py-12 border-y border-slate-200 dark:border-slate-700 transition-all duration-700 ${
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
+      }`}
+    >
+      {stats.map((stat, index) => (
+        <div
+          key={stat.label}
+          className="flex flex-col gap-1 text-center sm:text-left"
+          style={{ transitionDelay: `${index * 100}ms` }}
+        >
+          <span className="text-3xl font-bold text-blue-600 dark:text-blue-400">
+            {stat.value}
+          </span>
+          <span className="text-sm font-medium text-slate-900 dark:text-slate-200">
+            {stat.label}
+          </span>
+          <span className="text-xs text-slate-500 dark:text-slate-400">
+            {stat.description}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function AvailabilityBadge() {
+  return (
+    <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
+      <span className="relative flex h-2 w-2">
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+        <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+      </span>
+      <span className="text-xs font-medium text-green-700 dark:text-green-300">
+        Open to speaking opportunities
+      </span>
+    </div>
+  );
+}
+
+function ScrollIndicator() {
+  const [scrollProgress, setScrollProgress] = useState(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const totalHeight = document.documentElement.scrollHeight - window.innerHeight;
+      const progress = totalHeight > 0 ? (window.scrollY / totalHeight) * 100 : 0;
+      setScrollProgress(Math.min(progress, 100));
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <div className="fixed top-0 left-0 w-full h-0.5 z-[100]">
+      <div
+        className="h-full bg-blue-500 transition-all duration-150 ease-out"
+        style={{ width: `${scrollProgress}%` }}
+      />
+    </div>
+  );
+}
+
 export default function Home() {
   return (
     <Layout>
+      <ScrollIndicator />
       <main>
         <div className="py-24 max-w-3xl flex flex-col gap-8">
-          <p className="intro">
-            Hi, I'm David. I'm a designer and okayish developer based in Seattle. I'm currently working at {githubLink}{" "}
-            building {copilotLink}.
-          </p>
-          <p className="intro">Previously, I led design for {vsCodeLink} at Microsoft.</p>
+          <AvailabilityBadge />
+          <div className="flex flex-col gap-6">
+            <p className="intro">
+              Hi, I'm David. I'm a designer and okayish developer based in Seattle. I'm currently
+              working at {githubLink} building {copilotLink}.
+            </p>
+            <p className="intro">Previously, I led design for {vsCodeLink} at Microsoft.</p>
+            <p className="text-base text-slate-500 dark:text-slate-400 leading-relaxed max-w-2xl">
+              I'm passionate about making developer tools more approachable and delightful. I believe
+              that great design can reduce cognitive load and help developers stay in flow. My work
+              focuses on the intersection of AI, design systems, and developer experience.
+            </p>
+          </div>
+
+          {/* CTA buttons */}
+          <div className="flex flex-wrap gap-3 pt-2">
+            <Link
+              href="/#projects"
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition-colors shadow-sm"
+            >
+              View my work
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </Link>
+            <Link
+              href="mailto:hello@ddossett.com"
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg border border-slate-300 dark:border-slate-600 text-sm font-medium text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+            >
+              Get in touch
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+              </svg>
+            </Link>
+          </div>
         </div>
-        <div className="flex flex-col gap-14">
+
+        <StatsSection />
+
+        <div className="flex flex-col gap-14 mt-16">
           <Projects />
           <ExperienceList />
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,103 @@
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: {
+          50: '#eff6ff',
+          100: '#dbeafe',
+          200: '#bfdbfe',
+          300: '#93c5fd',
+          400: '#60a5fa',
+          500: '#3b82f6',
+          600: '#2563eb',
+          700: '#1d4ed8',
+          800: '#1e40af',
+          900: '#1e3a8a',
+          950: '#172554',
+        },
+        surface: {
+          DEFAULT: '#ffffff',
+          raised: '#f8fafc',
+          sunken: '#f1f5f9',
+          dark: {
+            DEFAULT: '#0f172a',
+            raised: '#1e293b',
+            sunken: '#020617',
+          },
+        },
+      },
+      spacing: {
+        '18': '4.5rem',
+        '88': '22rem',
+        '112': '28rem',
+        '128': '32rem',
+      },
+      fontSize: {
+        '2xs': ['0.625rem', { lineHeight: '0.875rem' }],
+      },
+      borderRadius: {
+        '4xl': '2rem',
+      },
+      boxShadow: {
+        'soft': '0 2px 15px -3px rgba(0, 0, 0, 0.07), 0 10px 20px -2px rgba(0, 0, 0, 0.04)',
+        'soft-lg': '0 10px 40px -10px rgba(0, 0, 0, 0.1), 0 2px 10px -2px rgba(0, 0, 0, 0.04)',
+        'inner-soft': 'inset 0 2px 4px 0 rgba(0, 0, 0, 0.04)',
+      },
+      animation: {
+        'fade-in': 'fadeIn 0.5s ease-out',
+        'fade-in-up': 'fadeInUp 0.5s ease-out',
+        'slide-in-right': 'slideInRight 0.3s ease-out',
+        'pulse-slow': 'pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+      },
+      keyframes: {
+        fadeIn: {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+        fadeInUp: {
+          '0%': { opacity: '0', transform: 'translateY(10px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        slideInRight: {
+          '0%': { opacity: '0', transform: 'translateX(-10px)' },
+          '100%': { opacity: '1', transform: 'translateX(0)' },
+        },
+      },
+      typography: (theme) => ({
+        DEFAULT: {
+          css: {
+            color: theme('colors.slate.700'),
+            a: {
+              color: theme('colors.blue.600'),
+              '&:hover': {
+                color: theme('colors.blue.800'),
+              },
+            },
+            'h1, h2, h3, h4': {
+              color: theme('colors.slate.900'),
+              fontWeight: theme('fontWeight.semibold'),
+            },
+          },
+        },
+        dark: {
+          css: {
+            color: theme('colors.slate.300'),
+            a: {
+              color: theme('colors.blue.400'),
+              '&:hover': {
+                color: theme('colors.blue.300'),
+              },
+            },
+            'h1, h2, h3, h4': {
+              color: theme('colors.slate.100'),
+            },
+          },
+        },
+      }),
+    },
     fontFamily: {
       sans: [
         '-apple-system',
@@ -13,6 +109,15 @@ module.exports = {
         'Apple Color Emoji',
         'Segoe UI Emoji',
         'Segoe UI Symbol',
+      ],
+      mono: [
+        'ui-monospace',
+        'SFMono-Regular',
+        'SF Mono',
+        'Menlo',
+        'Consolas',
+        'Liberation Mono',
+        'monospace',
       ],
     },
   },


### PR DESCRIPTION
The portfolio site had a minimal header, basic footer, and limited metadata — this PR brings the component library and page structure closer to a production-quality personal site.

## Approach

**Header & navigation:** Added a sticky header with backdrop blur on scroll, desktop nav links, and a mobile hamburger menu with full-screen overlay. Body scroll is locked when the mobile menu is open.

**Footer:** Replaced the plain link list with a structured footer containing SVG social icons, multi-column nav sections, and a copyright bar.

**Card component:** Introduced `variant` support (default/featured/compact), color-coded tags, hover animations with lift effect, and external link indicators.

**Experience section:** Added a vertical timeline UI with expandable highlights per role, skill tags, and company filter pills. Each role now carries richer data (skills, highlights, company URLs).

**Description row:** Extended with size variants, optional icons, badges, metadata, linked rows with arrow indicators, and hover states.

**Layout & SEO:** Added a `ThemeProvider` with system/light/dark support and localStorage persistence, canonical URLs, Open Graph images, Twitter card metadata, structured data (JSON-LD), and multiple favicon sizes.

**Homepage:** Added a scroll progress indicator, availability badge, stats section with intersection observer animations, CTA buttons, and an expanded intro paragraph.

**Tailwind config:** Extended with custom brand/surface color palettes, additional spacing/font-size tokens, custom animations and keyframes, typography plugin config, monospace font stack, and `darkMode: 'class'`.

## Notes

- The `ThemeProvider` is exported from `layout.tsx` but not yet wired into `_app.tsx` — it can be integrated in a follow-up.
- The analytics `gtag` config uses a placeholder ID (`G-XXXXXXXXXX`).
- All external links now use `target="_blank"` with `rel="noopener noreferrer"` consistently.