### PR TITLE
Add high contrast theme with toggle

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ThemeToggle } from "./theme-toggle";
 
 export const Header: React.FC = () => {
   return (
@@ -10,6 +11,7 @@ export const Header: React.FC = () => {
         <span className="text-2xl font-bold leading-3 text-blue-400">.</span>
         Seattle, WA
       </h1>
+      <ThemeToggle />
     </header>
   );
 };

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -33,6 +33,11 @@ function Layout({ children, title, description }: LayoutProps): JSX.Element {
         <meta name="twitter:description" content={pageDescription} />
 
         <link rel="icon" href="/favicon.ico" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{if(localStorage.getItem("theme")==="hc"){document.documentElement.setAttribute("data-theme","hc")}}catch(e){}`,
+          }}
+        />
       </Head>
       <Header />
       {children}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+
+export const ThemeToggle: React.FC = () => {
+  const [isHC, setIsHC] = useState(false);
+
+  useEffect(() => {
+    setIsHC(document.documentElement.getAttribute("data-theme") === "hc");
+  }, []);
+
+  const toggle = () => {
+    const next = !isHC;
+    setIsHC(next);
+    if (next) {
+      document.documentElement.setAttribute("data-theme", "hc");
+      localStorage.setItem("theme", "hc");
+    } else {
+      document.documentElement.removeAttribute("data-theme");
+      localStorage.removeItem("theme");
+    }
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label={isHC ? "Disable high contrast mode" : "Enable high contrast mode"}
+      title={isHC ? "Disable high contrast mode" : "Enable high contrast mode"}
+      className="hc-toggle"
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        aria-hidden="true"
+      >
+        <circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        <path d="M8 1a7 7 0 010 14V1z" fill="currentColor" />
+      </svg>
+    </button>
+  );
+};

--- a/public/globals.css
+++ b/public/globals.css
@@ -55,3 +55,80 @@
   line-height: 2.2rem;
   letter-spacing: -.0125rem;
 }
+
+/* Theme toggle button */
+.hc-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  border: 1.5px solid;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: all 150ms;
+  text-decoration: none;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.hc-toggle:hover {
+  @apply bg-slate-100 dark:bg-gray-800;
+}
+
+/* High Contrast Theme */
+[data-theme="hc"] body {
+  background-color: #000000 !important;
+  color: #ffffff !important;
+}
+
+[data-theme="hc"] h1,
+[data-theme="hc"] h2,
+[data-theme="hc"] h3 {
+  color: #ffffff !important;
+}
+
+[data-theme="hc"] h2 {
+  color: #ffff00 !important;
+}
+
+[data-theme="hc"] p,
+[data-theme="hc"] span {
+  color: #ffffff !important;
+}
+
+[data-theme="hc"] a {
+  color: #ffff00 !important;
+  text-decoration: underline !important;
+  background-color: transparent !important;
+}
+
+[data-theme="hc"] a:hover,
+[data-theme="hc"] a:focus-visible {
+  color: #00e5ff !important;
+  background-color: transparent !important;
+  outline: 2px solid #ffff00;
+  outline-offset: 2px;
+}
+
+[data-theme="hc"] ::selection {
+  background-color: #ffff00 !important;
+  color: #000000 !important;
+}
+
+[data-theme="hc"] img {
+  outline: 2px solid #ffffff;
+}
+
+[data-theme="hc"] .hc-toggle {
+  background-color: #ffff00 !important;
+  color: #000000 !important;
+  border-color: #ffff00 !important;
+}
+
+[data-theme="hc"] .hc-toggle:hover {
+  background-color: #00e5ff !important;
+  border-color: #00e5ff !important;
+}


### PR DESCRIPTION
The site supports light and dark mode via Tailwind's `dark:` variants, but has no high contrast option for users who need stronger visual separation.

This adds a high contrast (HC) theme following Windows High Contrast conventions — pure black background, white text, yellow links and accents, cyan hover states, and visible outlines on images and interactive elements.

**Approach:**
- HC theme is implemented as CSS overrides triggered by a `data-theme="hc"` attribute on `<html>`, layered on top of the existing light/dark system without disrupting it
- A toggle button (contrast icon) is added to the header — it turns yellow when HC is active
- Theme preference is persisted in `localStorage`, with an inline `<script>` in `<Head>` to apply it before paint and avoid a flash of unstyled content

**Files changed:**
- `public/globals.css` — HC theme CSS and toggle button styles
- `components/theme-toggle.tsx` — new toggle component
- `components/header.tsx` — wires up the toggle
- `components/layout.tsx` — inline script for flash prevention