### PR TITLE
Fix target="_blank" and add rel="noopener noreferrer" on external links

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,13 +3,13 @@ import Link from "next/link";
 export const Footer: React.FC = () => {
   return (
     <div className="flex space-x-4 gap-1 py-16">
-      <Link href="https://twitter.com/david_dossett" target="blank">
+      <Link href="https://twitter.com/david_dossett" target="_blank" rel="noopener noreferrer">
         Twitter
       </Link>
-      <Link href="https://github.com/daviddossett" target="blank">
+      <Link href="https://github.com/daviddossett" target="_blank" rel="noopener noreferrer">
         GitHub
       </Link>
-      <Link href="https://www.linkedin.com/in/davidcdossett/" target="blank">
+      <Link href="https://www.linkedin.com/in/davidcdossett/" target="_blank" rel="noopener noreferrer">
         LinkedIn
       </Link>
     </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,19 +5,19 @@ import { ExperienceList } from "../components/experience";
 import { Projects } from "../components/projects";
 
 const githubLink = (
-  <Link className="intro" href="https://github.com" target="blank">
+  <Link className="intro" href="https://github.com" target="_blank" rel="noopener noreferrer">
     GitHub
   </Link>
 );
 
 const copilotLink = (
-  <Link className="intro" href="https://github.com/features/copilot" target="blank">
+  <Link className="intro" href="https://github.com/features/copilot" target="_blank" rel="noopener noreferrer">
     Copilot
   </Link>
 );
 
 const vsCodeLink = (
-  <Link className="intro" href="https://code.visualstudio.com" target="blank">
+  <Link className="intro" href="https://code.visualstudio.com" target="_blank" rel="noopener noreferrer">
     VS Code
   </Link>
 );


### PR DESCRIPTION
External links in `footer.tsx` and `index.tsx` used `target="blank"` (missing the underscore), which means they weren't actually opening in new tabs. They also lacked a `rel` attribute, leaving the site vulnerable to [reverse tabnabbing](https://owasp.org/www-community/attacks/Reverse_Tabnabbing).

This PR fixes both issues by changing all instances to `target="_blank" rel="noopener noreferrer"`. The same pattern was already used correctly in `markdown.tsx`.