### PR TITLE
Harden markdown fetch and external link rel

### DIFF
--- a/components/markdown.tsx
+++ b/components/markdown.tsx
@@ -6,27 +6,33 @@ interface MarkdownRendererProps {
 }
 
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ path }) => {
-  const [content, setContent] = useState("");
+  const [content, setContent] = useState<string>("");
 
   useEffect(() => {
+    const controller = new AbortController();
+
     const fetchData = async () => {
       try {
-        const res = await fetch(path);
+        const res = await fetch(path, { signal: controller.signal });
         const text = await res.text();
         setContent(text);
       } catch (error) {
-        console.error("Error fetching markdown content:", error);
+        if ((error as Error).name !== "AbortError") {
+          console.error("Error fetching markdown content:", error);
+        }
       }
     };
 
     fetchData();
+
+    return () => controller.abort();
   }, [path]);
 
   return (
     <Markdown
       components={{
         a: ({ node, ...props }) => (
-          <a target="_blank" rel="noopener noreferrer" {...props} />
+          <a target="_blank" rel="noopener noreferrer nofollow" {...props} />
         ),
       }}
     >


### PR DESCRIPTION
Small hardening pass on `MarkdownRenderer` to prevent stale state updates and tighten outbound link behavior.

- **Abort-safe fetch:** wraps the `useEffect` fetch in an `AbortController` so in-flight requests are cancelled when `path` changes or the component unmounts. Also suppresses the expected `AbortError` from the error log.
- **Link rel hardening:** adds `nofollow` alongside `noopener noreferrer` on rendered anchors so external links don't pass ranking signals from rendered markdown.

No behavioral change for successful fetches or for non-link markdown rendering.