### PR TITLE
Surface fetch errors in MarkdownRenderer

### DIFF
--- a/components/markdown.tsx
+++ b/components/markdown.tsx
@@ -8,19 +8,30 @@ interface MarkdownRendererProps {
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ path }) => {
   const [content, setContent] = useState("");
 
+  const [error, setError] = useState<string | null>(null);
+
   useEffect(() => {
     const fetchData = async () => {
       try {
         const res = await fetch(path);
+        if (!res.ok) {
+          throw new Error(`Failed to fetch markdown: ${res.status}`);
+        }
         const text = await res.text();
         setContent(text);
-      } catch (error) {
-        console.error("Error fetching markdown content:", error);
+        setError(null);
+      } catch (err) {
+        console.error("Error fetching markdown content:", err);
+        setError(err instanceof Error ? err.message : "Unknown error");
       }
     };
 
     fetchData();
   }, [path]);
+
+  if (error) {
+    return <p>Error loading content: {error}</p>;
+  }
 
   return (
     <Markdown


### PR DESCRIPTION
Previously, if `fetch` in `MarkdownRenderer` returned a non-2xx response, the component would happily render the error body as markdown, and any thrown error was only logged to the console. That made failed loads invisible to users.

This PR tightens the fetch path:

- Check `res.ok` and throw on non-2xx responses so server errors aren't treated as content.
- Track an `error` state and render a simple "Error loading content" message when the fetch fails, instead of silently showing an empty component.

Small, contained change to `components/markdown.tsx` only.