### PR TITLE
Fix footer external links to open in a new tab

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -4,13 +4,25 @@ import Link from "next/link";
 export const Footer: React.FC = () => {
   return (
     <div className="flex space-x-4 gap-1 py-16">
-      <Link href="https://twitter.com/david_dossett" target="blank">
+      <Link
+        href="https://twitter.com/david_dossett"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Twitter
       </Link>
-      <Link href="https://github.com/daviddossett" target="blank">
+      <Link
+        href="https://github.com/daviddossett"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         GitHub
       </Link>
-      <Link href="https://www.linkedin.com/in/davidcdossett/" target="blank">
+      <Link
+        href="https://www.linkedin.com/in/davidcdossett/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         LinkedIn
       </Link>
     </div>


### PR DESCRIPTION
The footer social links used `target="blank"`, which opens links in a window literally named "blank" rather than a new browser tab. This fixes them and hardens the external links.

## Changes
- Change `target="blank"` to `target="_blank"` on the Twitter, GitHub, and LinkedIn links so they open in a new tab as intended.
- Add `rel="noopener noreferrer"` to each external link to prevent the opened page from accessing `window.opener` and to avoid leaking the referrer.

Scope is limited to `components/footer.tsx`.